### PR TITLE
Support open swap requests and richer metadata

### DIFF
--- a/Migrations/20251010120000_MakeSwapRecipientOptional.cs
+++ b/Migrations/20251010120000_MakeSwapRecipientOptional.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShiftManager.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeSwapRecipientOptional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "ToUserId",
+                table: "SwapRequests",
+                type: "INTEGER",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "INTEGER",
+                oldNullable: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "ToUserId",
+                table: "SwapRequests",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "INTEGER",
+                oldNullable: true);
+        }
+    }
+}

--- a/Migrations/AppDbContextModelSnapshot.cs
+++ b/Migrations/AppDbContextModelSnapshot.cs
@@ -193,7 +193,7 @@ namespace ShiftManager.Migrations
                     b.Property<int>("Status")
                         .HasColumnType("INTEGER");
 
-                    b.Property<int>("ToUserId")
+                    b.Property<int?>("ToUserId")
                         .HasColumnType("INTEGER");
 
                     b.HasKey("Id");

--- a/Models/SwapRequest.cs
+++ b/Models/SwapRequest.cs
@@ -6,7 +6,7 @@ public class SwapRequest
 {
     public int Id { get; set; }
     public int FromAssignmentId { get; set; } // The original assignment owned by the requesting employee
-    public int ToUserId { get; set; }         // The user they propose to take their shift
+    public int? ToUserId { get; set; }        // The user they propose to take their shift (null = open offer)
     public RequestStatus Status { get; set; } = RequestStatus.Pending;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/Pages/My/Requests.cshtml
+++ b/Pages/My/Requests.cshtml
@@ -67,7 +67,20 @@
                         <span asp-validation-for="SwapRequest.ShiftId" style="color: var(--danger); font-size: 0.8rem;"></span>
                     </div>
                     <div style="margin-bottom: 1.5rem;">
-                        <p style="color: var(--muted); font-size: 0.9rem; margin: 0;">This will create an open swap request that other employees can accept, or a manager can assign to someone.</p>
+                        <label asp-for="SwapRequest.ToUserId" style="display: block; font-weight: 600; margin-bottom: 0.5rem; color: var(--text);">Send To (optional)</label>
+                        <select asp-for="SwapRequest.ToUserId" style="width: 100%; padding: 0.75rem; border: 1px solid var(--border); border-radius: 0.5rem; background: var(--surface);">
+                            <option value="">Leave request open for any teammate</option>
+                            @foreach (var recipient in Model.PotentialRecipients)
+                            {
+                                <option value="@recipient.Id">@recipient.DisplayName (@recipient.Email)</option>
+                            }
+                        </select>
+                        <span asp-validation-for="SwapRequest.ToUserId" style="color: var(--danger); font-size: 0.8rem;"></span>
+                        <p style="color: var(--muted); font-size: 0.85rem; margin-top: 0.5rem;">Pick a coworker if you already have someone ready to swap with you, or leave the request open so anyone (or a manager) can volunteer.</p>
+                        @if (!Model.PotentialRecipients.Any())
+                        {
+                            <p style="color: var(--muted); font-size: 0.8rem; margin-top: 0.5rem;">No teammates available? Leaving the request open lets managers reassign it when someone becomes available.</p>
+                        }
                     </div>
                     <button type="submit" style="background: var(--primary); color: white; border: none; padding: 0.75rem 1.5rem; border-radius: 0.5rem; font-weight: 600; cursor: pointer; width: 100%;">Request Shift Swap</button>
                 </form>
@@ -129,6 +142,7 @@
                         <thead>
                             <tr style="border-bottom: 1px solid var(--border);">
                                 <th style="text-align: left; padding: 0.75rem 0; color: var(--text); font-weight: 600;">Shift</th>
+                                <th style="text-align: left; padding: 0.75rem 0; color: var(--text); font-weight: 600;">Recipient</th>
                                 <th style="text-align: left; padding: 0.75rem 0; color: var(--text); font-weight: 600;">Status</th>
                             </tr>
                         </thead>
@@ -137,8 +151,23 @@
                             {
                                 <tr style="border-bottom: 1px solid var(--border);">
                                     <td style="padding: 0.75rem 0; color: var(--text);">
-                                        @request.ShiftDate.ToString("MMM dd, yyyy")
-                                        <br><small style="color: var(--muted);">@request.ShiftTypeName</small>
+                                        <strong>@request.ShiftDate.ToString("MMM dd, yyyy")</strong>
+                                        <br /><small style="color: var(--muted);">@request.ShiftInstanceName</small>
+                                        <br /><small style="color: var(--muted);">@request.ShiftTimeRange</small>
+                                    </td>
+                                    <td style="padding: 0.75rem 0; color: var(--text);">
+                                        @if (request.IsOpen)
+                                        {
+                                            <span style="color: var(--muted);">Open to any teammate</span>
+                                        }
+                                        else
+                                        {
+                                            <span>@request.ToUserName</span>
+                                            @if (!string.IsNullOrEmpty(request.ToUserEmail))
+                                            {
+                                                <br /><small style="color: var(--muted);">@request.ToUserEmail</small>
+                                            }
+                                        }
                                     </td>
                                     <td style="padding: 0.75rem 0;">
                                         <span style="padding: 0.25rem 0.5rem; border-radius: 0.25rem; font-size: 0.8rem; font-weight: 600;

--- a/Pages/Requests/Index.cshtml
+++ b/Pages/Requests/Index.cshtml
@@ -39,23 +39,44 @@
 <div class="card">
     <h3 style="margin-top:0">Pending Swaps</h3>
     <table>
-        <thead><tr><th>From</th><th>Shift</th><th>Proposed To</th><th></th></tr></thead>
+        <thead><tr><th>From</th><th>Shift</th><th>Recipient</th><th></th></tr></thead>
         <tbody>
         @foreach (var s in Model.Swaps)
         {
             <tr>
                 <td>@s.FromUser</td>
-                <td>@s.When</td>
-                <td>@s.ToUser</td>
+                <td>
+                    <strong>@s.ShiftDate.ToString("yyyy-MM-dd")</strong><br />
+                    <small style="color:var(--muted);">@s.ShiftName</small><br />
+                    <small style="color:var(--muted);">@s.Start.ToString("HH:mm") - @s.End.ToString("HH:mm")</small>
+                </td>
+                <td>
+                    @if (string.IsNullOrEmpty(s.RecipientName))
+                    {
+                        <span style="color:var(--muted);">Open offer (no teammate selected)</span>
+                    }
+                    else
+                    {
+                        <div>@s.RecipientName</div>
+                        @if (!string.IsNullOrEmpty(s.RecipientEmail))
+                        {
+                            <small style="color:var(--muted);">@s.RecipientEmail</small>
+                        }
+                    }
+                </td>
                 <td style="white-space:nowrap">
                     <form method="post" asp-page-handler="ApproveSwap" style="display:inline">
                         <input type="hidden" name="id" value="@s.Id" />
-                        <button class="btn btn-primary">Approve</button>
+                        <button class="btn btn-primary" @(string.IsNullOrEmpty(s.RecipientName) ? "disabled" : null)>Approve</button>
                     </form>
                     <form method="post" asp-page-handler="DeclineSwap" style="display:inline">
                         <input type="hidden" name="id" value="@s.Id" />
                         <button class="btn btn-ghost">Decline</button>
                     </form>
+                    @if (string.IsNullOrEmpty(s.RecipientName))
+                    {
+                        <div style="margin-top:0.25rem; font-size:0.8rem; color:var(--muted);">Assign a teammate before approving an open request.</div>
+                    }
                 </td>
             </tr>
         }

--- a/Pages/Requests/Swaps/Create.cshtml
+++ b/Pages/Requests/Swaps/Create.cshtml
@@ -19,12 +19,13 @@
             </label>
             <label>Proposed to user<br />
                 <select class="input" asp-for="ToUserId">
-                    <option value="">-- choose a user --</option>
+                    <option value="">Leave open for any teammate</option>
                     @foreach (var u in Model.OtherUsers)
                     {
                         <option value="@u.Id">@u.DisplayName (@u.Email)</option>
                     }
                 </select>
+                <small style="display:block; color:var(--muted); margin-top:.25rem;">Pick a teammate if you have a specific partner, or leave the request open to let others volunteer later.</small>
             </label>
             <button class="btn btn-primary" type="submit">Submit</button>
         </div>

--- a/Pages/Requests/Swaps/Create.cshtml.cs
+++ b/Pages/Requests/Swaps/Create.cshtml.cs
@@ -38,8 +38,20 @@ public class CreateModel : PageModel
     public async Task<IActionResult> OnPostAsync()
     {
         await OnGetAsync();
-        if (SelectedAssignmentId is null || ToUserId is null) return Page();
-        _db.SwapRequests.Add(new SwapRequest { FromAssignmentId = SelectedAssignmentId.Value, ToUserId = ToUserId.Value });
+
+        if (SelectedAssignmentId is null)
+        {
+            ModelState.AddModelError(nameof(SelectedAssignmentId), "Please choose one of your upcoming shifts.");
+            return Page();
+        }
+
+        if (ToUserId.HasValue && !OtherUsers.Any(u => u.Id == ToUserId.Value))
+        {
+            ModelState.AddModelError(nameof(ToUserId), "Please select a valid teammate or leave the request open.");
+            return Page();
+        }
+
+        _db.SwapRequests.Add(new SwapRequest { FromAssignmentId = SelectedAssignmentId.Value, ToUserId = ToUserId });
         await _db.SaveChangesAsync();
         return RedirectToPage("/Requests/Index");
     }


### PR DESCRIPTION
## Summary
- enrich the employee requests workflow so swap listings include the actual shift date/time and optional recipient details, while offering an easy way to leave a request open
- adjust the manager pending swap review experience to surface the same metadata, respect open offers during approval, and prevent accidental approvals without an assignee
- make swap recipients optional at the data layer with a new migration so open requests persist cleanly and update the admin swap creation form accordingly

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68dac762065083298392478846efb6c9