### PR TITLE
Guard admin mutations by company and add scope tests

### DIFF
--- a/Pages/Admin/Users.cshtml.cs
+++ b/Pages/Admin/Users.cshtml.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using ShiftManager.Data;
 using ShiftManager.Models;
 using ShiftManager.Models.Support;
+using ShiftManager.Services;
 using System.ComponentModel.DataAnnotations;
 
 namespace ShiftManager.Pages.Admin;
@@ -15,10 +16,12 @@ public class UsersModel : PageModel
 {
     private readonly AppDbContext _db;
     private readonly ILogger<UsersModel> _logger;
-    public UsersModel(AppDbContext db, ILogger<UsersModel> logger)
+    private readonly ICompanyScopeService _companyScope;
+    public UsersModel(AppDbContext db, ILogger<UsersModel> logger, ICompanyScopeService companyScope)
     {
         _db = db;
         _logger = logger;
+        _companyScope = companyScope;
     }
 
     public record UserVM(int Id, string DisplayName, string Email, string Role, bool IsActive);
@@ -32,7 +35,7 @@ public class UsersModel : PageModel
 
     public async Task OnGetAsync()
     {
-        var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
+        var companyId = _companyScope.GetCurrentCompanyId(User);
         Users = await _db.Users.Where(u => u.CompanyId == companyId)
             .OrderBy(u => u.DisplayName)
             .Select(u => new UserVM(u.Id, u.DisplayName, u.Email, u.Role.ToString(), u.IsActive)).ToListAsync();
@@ -46,7 +49,7 @@ public class UsersModel : PageModel
 
         if (await _db.Users.AnyAsync(u => u.Email == NewEmail)) { Error = "Email already exists."; return Page(); }
 
-        var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
+        var companyId = _companyScope.GetCurrentCompanyId(User);
         var (h, s) = PasswordHasher.CreateHash(NewPassword);
         _db.Users.Add(new AppUser
         {
@@ -64,27 +67,38 @@ public class UsersModel : PageModel
 
     public async Task<IActionResult> OnPostToggleAsync(int id)
     {
-        var u = await _db.Users.FindAsync(id);
-        if (u != null) { u.IsActive = !u.IsActive; await _db.SaveChangesAsync(); }
+        var companyId = _companyScope.GetCurrentCompanyId(User);
+        var user = await _companyScope.GetCompanyUserAsync(id, companyId);
+        if (user == null) return Forbid();
+
+        user.IsActive = !user.IsActive;
+        await _db.SaveChangesAsync();
         return RedirectToPage();
     }
 
     public async Task<IActionResult> OnPostRoleAsync(int id, string role)
     {
-        var u = await _db.Users.FindAsync(id);
-        if (u != null) { u.Role = Enum.Parse<UserRole>(role); await _db.SaveChangesAsync(); }
+        var companyId = _companyScope.GetCurrentCompanyId(User);
+        var user = await _companyScope.GetCompanyUserAsync(id, companyId);
+        if (user == null) return Forbid();
+
+        user.Role = Enum.Parse<UserRole>(role);
+        await _db.SaveChangesAsync();
         return RedirectToPage();
     }
 
     public async Task<IActionResult> OnPostResetPasswordAsync(int id, string newPassword)
     {
-        var u = await _db.Users.FindAsync(id);
-        if (u != null && !string.IsNullOrWhiteSpace(newPassword))
-        {
-            var (h, s) = PasswordHasher.CreateHash(newPassword);
-            u.PasswordHash = h; u.PasswordSalt = s;
-            await _db.SaveChangesAsync();
-        }
+        if (string.IsNullOrWhiteSpace(newPassword)) return RedirectToPage();
+
+        var companyId = _companyScope.GetCurrentCompanyId(User);
+        var user = await _companyScope.GetCompanyUserAsync(id, companyId);
+        if (user == null) return Forbid();
+
+        var (h, s) = PasswordHasher.CreateHash(newPassword);
+        user.PasswordHash = h;
+        user.PasswordSalt = s;
+        await _db.SaveChangesAsync();
         return RedirectToPage();
     }
 
@@ -95,6 +109,7 @@ public class UsersModel : PageModel
         try
         {
             var currentUserId = int.Parse(User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)!.Value);
+            var companyId = _companyScope.GetCurrentCompanyId(User);
 
             // Prevent self-deletion
             if (id == currentUserId)
@@ -105,7 +120,7 @@ public class UsersModel : PageModel
                 return Page();
             }
 
-            var user = await _db.Users.FindAsync(id);
+            var user = await _companyScope.GetCompanyUserAsync(id, companyId);
             if (user == null)
             {
                 _logger.LogWarning("User {UserId} not found for deletion", id);
@@ -114,19 +129,13 @@ public class UsersModel : PageModel
                 return Page();
             }
 
-            var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
-            if (user.CompanyId != companyId)
-            {
-                _logger.LogWarning("User {CurrentUserId} attempted to delete user {TargetUserId} from different company", currentUserId, id);
-                Error = "You can only delete users from your own company.";
-                await OnGetAsync();
-                return Page();
-            }
-
             _logger.LogInformation("Starting deletion of user {UserId} ({UserName}) by admin {CurrentUserId}", id, user.DisplayName, currentUserId);
 
             // 1. Remove all shift assignments
-            var shiftAssignments = await _db.ShiftAssignments.Where(sa => sa.UserId == id).ToListAsync();
+            var shiftAssignments = await (from sa in _db.ShiftAssignments
+                                          join si in _db.ShiftInstances on sa.ShiftInstanceId equals si.Id
+                                          where sa.UserId == id && si.CompanyId == companyId
+                                          select sa).ToListAsync();
             if (shiftAssignments.Any())
             {
                 _logger.LogInformation("Removing {Count} shift assignments for user {UserId}", shiftAssignments.Count, id);

--- a/Program.cs
+++ b/Program.cs
@@ -48,6 +48,7 @@ builder.Services.AddAuthorization(options =>
 
 builder.Services.AddScoped<IConflictChecker, ConflictChecker>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
+builder.Services.AddScoped<ICompanyScopeService, CompanyScopeService>();
 
 var app = builder.Build();
 

--- a/Services/CompanyScopeService.cs
+++ b/Services/CompanyScopeService.cs
@@ -1,0 +1,85 @@
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using ShiftManager.Data;
+using ShiftManager.Models;
+
+namespace ShiftManager.Services;
+
+public interface ICompanyScopeService
+{
+    int GetCurrentCompanyId(ClaimsPrincipal user);
+    Task<AppUser?> GetCompanyUserAsync(int userId, int companyId);
+    Task<TimeOffRequest?> GetCompanyTimeOffRequestAsync(int requestId, int companyId);
+    Task<SwapRequest?> GetCompanySwapRequestAsync(int requestId, int companyId);
+    Task<ShiftAssignment?> GetCompanyShiftAssignmentAsync(int assignmentId, int companyId);
+    Task<List<ShiftAssignment>> GetAssignmentsForUserInRangeAsync(int userId, DateOnly startDate, DateOnly endDate, int companyId);
+}
+
+public class CompanyScopeService : ICompanyScopeService
+{
+    private readonly AppDbContext _db;
+
+    public CompanyScopeService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public int GetCurrentCompanyId(ClaimsPrincipal user)
+    {
+        var claim = user.FindFirst("CompanyId")?.Value
+            ?? throw new InvalidOperationException("CompanyId claim is missing for the current user.");
+
+        return int.Parse(claim);
+    }
+
+    public Task<AppUser?> GetCompanyUserAsync(int userId, int companyId)
+    {
+        return _db.Users.SingleOrDefaultAsync(u => u.Id == userId && u.CompanyId == companyId);
+    }
+
+    public Task<TimeOffRequest?> GetCompanyTimeOffRequestAsync(int requestId, int companyId)
+    {
+        return (from request in _db.TimeOffRequests
+                join user in _db.Users on request.UserId equals user.Id
+                where request.Id == requestId && user.CompanyId == companyId
+                select request).SingleOrDefaultAsync();
+    }
+
+    public Task<SwapRequest?> GetCompanySwapRequestAsync(int requestId, int companyId)
+    {
+        return (from swap in _db.SwapRequests
+                join assignment in _db.ShiftAssignments on swap.FromAssignmentId equals assignment.Id
+                join instance in _db.ShiftInstances on assignment.ShiftInstanceId equals instance.Id
+                join fromUser in _db.Users on assignment.UserId equals fromUser.Id
+                join toUser in _db.Users on swap.ToUserId equals toUser.Id
+                where swap.Id == requestId
+                      && instance.CompanyId == companyId
+                      && fromUser.CompanyId == companyId
+                      && toUser.CompanyId == companyId
+                select swap).SingleOrDefaultAsync();
+    }
+
+    public Task<ShiftAssignment?> GetCompanyShiftAssignmentAsync(int assignmentId, int companyId)
+    {
+        return (from assignment in _db.ShiftAssignments
+                join instance in _db.ShiftInstances on assignment.ShiftInstanceId equals instance.Id
+                join user in _db.Users on assignment.UserId equals user.Id
+                where assignment.Id == assignmentId
+                      && instance.CompanyId == companyId
+                      && user.CompanyId == companyId
+                select assignment).SingleOrDefaultAsync();
+    }
+
+    public Task<List<ShiftAssignment>> GetAssignmentsForUserInRangeAsync(int userId, DateOnly startDate, DateOnly endDate, int companyId)
+    {
+        return (from assignment in _db.ShiftAssignments
+                join instance in _db.ShiftInstances on assignment.ShiftInstanceId equals instance.Id
+                join user in _db.Users on assignment.UserId equals user.Id
+                where assignment.UserId == userId
+                      && instance.WorkDate >= startDate
+                      && instance.WorkDate <= endDate
+                      && instance.CompanyId == companyId
+                      && user.CompanyId == companyId
+                select assignment).ToListAsync();
+    }
+}

--- a/ShiftManager.Tests/CompanyScopeGuardTests.cs
+++ b/ShiftManager.Tests/CompanyScopeGuardTests.cs
@@ -1,0 +1,181 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ShiftManager.Data;
+using ShiftManager.Models;
+using ShiftManager.Models.Support;
+using ShiftManager.Pages.Admin;
+using ShiftManager.Pages.Requests;
+using ShiftManager.Services;
+using Xunit;
+
+namespace ShiftManager.Tests;
+
+public class CompanyScopeGuardTests
+{
+    [Fact]
+    public async Task ApproveTimeOff_FromDifferentCompany_IsRejected()
+    {
+        await using var context = CreateContext();
+        var (companyA, companyB) = await SeedCompaniesAsync(context);
+        var admin = await SeedUserAsync(context, companyA.Id, "admin@a.test", UserRole.Admin);
+        var otherUser = await SeedUserAsync(context, companyB.Id, "employee@b.test", UserRole.Employee);
+
+        var request = new TimeOffRequest
+        {
+            UserId = otherUser.Id,
+            StartDate = DateOnly.FromDateTime(DateTime.Today),
+            EndDate = DateOnly.FromDateTime(DateTime.Today.AddDays(2)),
+            Reason = "Vacation"
+        };
+        context.TimeOffRequests.Add(request);
+        await context.SaveChangesAsync();
+
+        var companyScope = new CompanyScopeService(context);
+        var page = new IndexModel(context, new ConflictChecker(context), new StubNotificationService(), NullLogger<IndexModel>.Instance, companyScope);
+        AttachUser(page, admin.Id, companyA.Id);
+
+        var result = await page.OnPostApproveTimeOffAsync(request.Id);
+
+        Assert.IsType<ForbidResult>(result);
+        Assert.Equal(RequestStatus.Pending, (await context.TimeOffRequests.SingleAsync()).Status);
+    }
+
+    [Fact]
+    public async Task ApproveSwap_FromDifferentCompany_IsRejected()
+    {
+        await using var context = CreateContext();
+        var (companyA, companyB) = await SeedCompaniesAsync(context);
+        var admin = await SeedUserAsync(context, companyA.Id, "admin@a.test", UserRole.Admin);
+        var fromUser = await SeedUserAsync(context, companyB.Id, "from@b.test", UserRole.Employee);
+        var toUser = await SeedUserAsync(context, companyB.Id, "to@b.test", UserRole.Employee);
+
+        var shiftType = new ShiftType { Key = "TEST", Start = new TimeOnly(8, 0), End = new TimeOnly(16, 0) };
+        context.ShiftTypes.Add(shiftType);
+        await context.SaveChangesAsync();
+
+        var instance = new ShiftInstance
+        {
+            CompanyId = companyB.Id,
+            ShiftTypeId = shiftType.Id,
+            WorkDate = DateOnly.FromDateTime(DateTime.Today),
+            Name = "Morning"
+        };
+        context.ShiftInstances.Add(instance);
+        await context.SaveChangesAsync();
+
+        var assignment = new ShiftAssignment
+        {
+            ShiftInstanceId = instance.Id,
+            UserId = fromUser.Id
+        };
+        context.ShiftAssignments.Add(assignment);
+        await context.SaveChangesAsync();
+
+        var swapRequest = new SwapRequest
+        {
+            FromAssignmentId = assignment.Id,
+            ToUserId = toUser.Id
+        };
+        context.SwapRequests.Add(swapRequest);
+        await context.SaveChangesAsync();
+
+        var companyScope = new CompanyScopeService(context);
+        var page = new IndexModel(context, new ConflictChecker(context), new StubNotificationService(), NullLogger<IndexModel>.Instance, companyScope);
+        AttachUser(page, admin.Id, companyA.Id);
+
+        var result = await page.OnPostApproveSwapAsync(swapRequest.Id);
+
+        Assert.IsType<ForbidResult>(result);
+        Assert.Equal(RequestStatus.Pending, (await context.SwapRequests.SingleAsync()).Status);
+    }
+
+    [Fact]
+    public async Task ToggleUser_FromDifferentCompany_IsRejected()
+    {
+        await using var context = CreateContext();
+        var (companyA, companyB) = await SeedCompaniesAsync(context);
+        var admin = await SeedUserAsync(context, companyA.Id, "admin@a.test", UserRole.Admin);
+        var otherUser = await SeedUserAsync(context, companyB.Id, "employee@b.test", UserRole.Employee);
+
+        var companyScope = new CompanyScopeService(context);
+        var page = new UsersModel(context, NullLogger<UsersModel>.Instance, companyScope);
+        AttachUser(page, admin.Id, companyA.Id);
+
+        var result = await page.OnPostToggleAsync(otherUser.Id);
+
+        Assert.IsType<ForbidResult>(result);
+        Assert.True((await context.Users.SingleAsync(u => u.Id == otherUser.Id)).IsActive);
+    }
+
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static async Task<(Company companyA, Company companyB)> SeedCompaniesAsync(AppDbContext context)
+    {
+        var companyA = new Company { Name = "Company A" };
+        var companyB = new Company { Name = "Company B" };
+        context.Companies.AddRange(companyA, companyB);
+        await context.SaveChangesAsync();
+        return (companyA, companyB);
+    }
+
+    private static async Task<AppUser> SeedUserAsync(AppDbContext context, int companyId, string email, UserRole role)
+    {
+        var user = new AppUser
+        {
+            CompanyId = companyId,
+            Email = email,
+            DisplayName = email,
+            Role = role,
+            IsActive = true,
+            PasswordHash = Array.Empty<byte>(),
+            PasswordSalt = Array.Empty<byte>()
+        };
+        context.Users.Add(user);
+        await context.SaveChangesAsync();
+        return user;
+    }
+
+    private static void AttachUser(PageModel model, int userId, int companyId)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString()),
+            new("CompanyId", companyId.ToString()),
+            new(ClaimTypes.Role, nameof(UserRole.Admin))
+        };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+        var httpContext = new DefaultHttpContext { User = principal };
+        model.PageContext = new PageContext
+        {
+            HttpContext = httpContext
+        };
+    }
+
+    private sealed class StubNotificationService : INotificationService
+    {
+        public Task CreateNotificationAsync(int userId, NotificationType type, string title, string message, int? relatedEntityId = null, string? relatedEntityType = null)
+            => Task.CompletedTask;
+
+        public Task CreateShiftAddedNotificationAsync(int userId, string shiftTypeName, DateOnly shiftDate, TimeOnly startTime, TimeOnly endTime)
+            => Task.CompletedTask;
+
+        public Task CreateShiftRemovedNotificationAsync(int userId, string shiftTypeName, DateOnly shiftDate, TimeOnly startTime, TimeOnly endTime)
+            => Task.CompletedTask;
+
+        public Task CreateTimeOffNotificationAsync(int userId, RequestStatus status, DateOnly startDate, DateOnly endDate, int requestId)
+            => Task.CompletedTask;
+
+        public Task CreateSwapRequestNotificationAsync(int userId, RequestStatus status, string shiftInfo, int requestId)
+            => Task.CompletedTask;
+    }
+}

--- a/ShiftManager.Tests/ShiftManager.Tests.csproj
+++ b/ShiftManager.Tests/ShiftManager.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ShiftManager.csproj" />
+  </ItemGroup>
+</Project>

--- a/ShiftManager.sln
+++ b/ShiftManager.sln
@@ -4,17 +4,23 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShiftManager", "ShiftManager.csproj", "{24E931EF-1D06-9E43-E5FB-AF0E807D4B70}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShiftManager.Tests", "ShiftManager.Tests/ShiftManager.Tests.csproj", "{90C7DAF3-8353-4160-B667-7CBB520E91A6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{24E931EF-1D06-9E43-E5FB-AF0E807D4B70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{24E931EF-1D06-9E43-E5FB-AF0E807D4B70}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{24E931EF-1D06-9E43-E5FB-AF0E807D4B70}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{24E931EF-1D06-9E43-E5FB-AF0E807D4B70}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{24E931EF-1D06-9E43-E5FB-AF0E807D4B70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{24E931EF-1D06-9E43-E5FB-AF0E807D4B70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{24E931EF-1D06-9E43-E5FB-AF0E807D4B70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{24E931EF-1D06-9E43-E5FB-AF0E807D4B70}.Release|Any CPU.Build.0 = Release|Any CPU
+{90C7DAF3-8353-4160-B667-7CBB520E91A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{90C7DAF3-8353-4160-B667-7CBB520E91A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{90C7DAF3-8353-4160-B667-7CBB520E91A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{90C7DAF3-8353-4160-B667-7CBB520E91A6}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add a company scope service that encapsulates company-aware entity lookups for admin flows
- enforce company scoping in admin request, user, and time-off page handlers before mutating state
- add in-memory tests to ensure cross-company approvals and user management actions are rejected

## Testing
- Not run (dotnet CLI not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68dac762dda883299844f2d0d8dd7969