### PR TITLE
Partition shift types per company

### DIFF
--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -33,6 +33,13 @@ public class AppDbContext : DbContext
             .Property(p => p.Start).HasConversion(timeConverter);
         modelBuilder.Entity<ShiftType>()
             .Property(p => p.End).HasConversion(timeConverter);
+        modelBuilder.Entity<ShiftType>()
+            .HasIndex(p => new { p.CompanyId, p.Key }).IsUnique();
+        modelBuilder.Entity<ShiftType>()
+            .HasOne(p => p.Company)
+            .WithMany()
+            .HasForeignKey(p => p.CompanyId)
+            .OnDelete(DeleteBehavior.Cascade);
 
         modelBuilder.Entity<ShiftInstance>()
             .Property(p => p.WorkDate).HasConversion(dateConverter);

--- a/Migrations/20251001000000_PartitionShiftTypesPerCompany.Designer.cs
+++ b/Migrations/20251001000000_PartitionShiftTypesPerCompany.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ShiftManager.Data;
 
@@ -10,9 +11,10 @@ using ShiftManager.Data;
 namespace ShiftManager.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251001000000_PartitionShiftTypesPerCompany")]
+    partial class PartitionShiftTypesPerCompany
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.9");

--- a/Migrations/20251001000000_PartitionShiftTypesPerCompany.cs
+++ b/Migrations/20251001000000_PartitionShiftTypesPerCompany.cs
@@ -1,0 +1,86 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShiftManager.Migrations
+{
+    /// <inheritdoc />
+    public partial class PartitionShiftTypesPerCompany : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CompanyId",
+                table: "ShiftTypes",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.Sql(@"
+                UPDATE ShiftTypes
+                SET CompanyId = (
+                    SELECT CompanyId
+                    FROM ShiftInstances
+                    WHERE ShiftInstances.ShiftTypeId = ShiftTypes.Id
+                    LIMIT 1
+                )
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM ShiftInstances
+                    WHERE ShiftInstances.ShiftTypeId = ShiftTypes.Id
+                );
+            ");
+
+            migrationBuilder.Sql(@"
+                UPDATE ShiftTypes
+                SET CompanyId = (
+                    SELECT Id
+                    FROM Companies
+                    ORDER BY Id
+                    LIMIT 1
+                )
+                WHERE CompanyId = 0;
+            ");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShiftTypes_CompanyId",
+                table: "ShiftTypes",
+                column: "CompanyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShiftTypes_CompanyId_Key",
+                table: "ShiftTypes",
+                columns: new[] { "CompanyId", "Key" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ShiftTypes_Companies_CompanyId",
+                table: "ShiftTypes",
+                column: "CompanyId",
+                principalTable: "Companies",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ShiftTypes_Companies_CompanyId",
+                table: "ShiftTypes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ShiftTypes_CompanyId_Key",
+                table: "ShiftTypes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ShiftTypes_CompanyId",
+                table: "ShiftTypes");
+
+            migrationBuilder.DropColumn(
+                name: "CompanyId",
+                table: "ShiftTypes");
+        }
+    }
+}

--- a/Models/ShiftType.cs
+++ b/Models/ShiftType.cs
@@ -5,7 +5,9 @@ namespace ShiftManager.Models;
 public class ShiftType
 {
     public int Id { get; set; }
+    public int CompanyId { get; set; }
     public string Key { get; set; } = string.Empty; // MORNING, NOON, NIGHT, MIDDLE
+    public Company Company { get; set; } = null!;
     [NotMapped]
     public string Name
     {

--- a/Pages/Admin/ShiftTypes.cshtml.cs
+++ b/Pages/Admin/ShiftTypes.cshtml.cs
@@ -18,14 +18,25 @@ public class ShiftTypesModel : PageModel
 
     public async Task OnGetAsync()
     {
-        var t = await _db.ShiftTypes.OrderBy(s => s.Key).ToListAsync();
+        var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
+        var t = await _db.ShiftTypes
+            .Where(s => s.CompanyId == companyId)
+            .OrderBy(s => s.Key)
+            .ToListAsync();
         Items = t.Select(x => new Item(x.Id, x.Key, x.Name, x.Start.ToString("HH:mm"), x.End.ToString("HH:mm"))).ToList();
     }
 
     public async Task<IActionResult> OnPostAsync(List<Item> items)
     {
+        var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
         var ids = items.Select(i => i.Id).ToList();
-        var types = await _db.ShiftTypes.Where(s => ids.Contains(s.Id)).ToListAsync();
+        var types = await _db.ShiftTypes
+            .Where(s => s.CompanyId == companyId && ids.Contains(s.Id))
+            .ToListAsync();
+        if (types.Count != ids.Count)
+        {
+            return Forbid();
+        }
         foreach (var it in items)
         {
             var t = types.First(x => x.Id == it.Id);

--- a/Pages/Assignments/Manage.cshtml.cs
+++ b/Pages/Assignments/Manage.cshtml.cs
@@ -38,7 +38,8 @@ public class ManageModel : PageModel
     public async Task<IActionResult> OnGetAsync()
     {
         var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
-        Type = await _db.ShiftTypes.FindAsync(ShiftTypeId);
+        Type = await _db.ShiftTypes
+            .FirstOrDefaultAsync(st => st.CompanyId == companyId && st.Id == ShiftTypeId);
         if (Type == null) return RedirectToPage("/Calendar/Month");
 
         Instance = await _db.ShiftInstances.FirstOrDefaultAsync(i => i.CompanyId == companyId && i.WorkDate == Date && i.ShiftTypeId == ShiftTypeId)

--- a/Pages/Calendar/Month.cshtml.cs
+++ b/Pages/Calendar/Month.cshtml.cs
@@ -58,7 +58,10 @@ public class MonthModel : PageModel
         var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
 
         // Load shift types
-        var types = await _db.ShiftTypes.OrderBy(s => s.Key).ToListAsync();
+        var types = await _db.ShiftTypes
+            .Where(st => st.CompanyId == companyId)
+            .OrderBy(s => s.Key)
+            .ToListAsync();
 
         // Prepare shift types for JavaScript
         ViewData["ShiftTypes"] = types.Select(t => new
@@ -152,6 +155,13 @@ public class MonthModel : PageModel
         _logger.LogInformation("Adjust staffing: date={Date} shiftTypeId={ShiftTypeId} delta={Delta}", payload.date, payload.shiftTypeId, payload.delta);
         var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
         var date = DateOnly.Parse(payload.date);
+
+        bool shiftTypeExists = await _db.ShiftTypes
+            .AnyAsync(st => st.CompanyId == companyId && st.Id == payload.shiftTypeId);
+        if (!shiftTypeExists)
+        {
+            return BadRequest(new { message = "Shift type not found." });
+        }
 
         var inst = await _db.ShiftInstances.FirstOrDefaultAsync(i => i.CompanyId == companyId && i.WorkDate == date && i.ShiftTypeId == payload.shiftTypeId);
         if (inst == null)

--- a/Pages/Requests/Index.cshtml.cs
+++ b/Pages/Requests/Index.cshtml.cs
@@ -123,7 +123,12 @@ public class IndexModel : PageModel
         if (si == null) { s.Status = RequestStatus.Declined; await _db.SaveChangesAsync(); return RedirectToPage(); }
 
         var shiftType = await _db.ShiftTypes.FindAsync(si.ShiftTypeId);
-        if (shiftType == null) { s.Status = RequestStatus.Declined; await _db.SaveChangesAsync(); return RedirectToPage(); }
+        if (shiftType == null || shiftType.CompanyId != si.CompanyId)
+        {
+            s.Status = RequestStatus.Declined;
+            await _db.SaveChangesAsync();
+            return RedirectToPage();
+        }
 
         var conflict = await _checker.CanAssignAsync(s.ToUserId, si);
         if (!conflict.Allowed)

--- a/Program.cs
+++ b/Program.cs
@@ -67,13 +67,13 @@ using (var scope = app.Services.CreateScope())
     var company = db.Companies.First();
 
     // Seed shift types (fixed keys)
-    if (!db.ShiftTypes.Any())
+    if (!db.ShiftTypes.Any(st => st.CompanyId == company.Id))
     {
         db.ShiftTypes.AddRange(new[] {
-            new ShiftType{ Key="MORNING", Start=new TimeOnly(8,0), End=new TimeOnly(16,0)},
-            new ShiftType{ Key="NOON", Start=new TimeOnly(16,0), End=new TimeOnly(0,0)},
-            new ShiftType{ Key="NIGHT", Start=new TimeOnly(0,0), End=new TimeOnly(8,0)},
-            new ShiftType{ Key="MIDDLE", Start=new TimeOnly(12,0), End=new TimeOnly(20,0)},
+            new ShiftType{ CompanyId = company.Id, Key="MORNING", Start=new TimeOnly(8,0), End=new TimeOnly(16,0)},
+            new ShiftType{ CompanyId = company.Id, Key="NOON", Start=new TimeOnly(16,0), End=new TimeOnly(0,0)},
+            new ShiftType{ CompanyId = company.Id, Key="NIGHT", Start=new TimeOnly(0,0), End=new TimeOnly(8,0)},
+            new ShiftType{ CompanyId = company.Id, Key="MIDDLE", Start=new TimeOnly(12,0), End=new TimeOnly(20,0)},
         });
         await db.SaveChangesAsync();
     }

--- a/Services/ConflictChecker.cs
+++ b/Services/ConflictChecker.cs
@@ -18,7 +18,8 @@ public class ConflictChecker : IConflictChecker
             return ConflictResult.Fail("User inactive or not found.");
 
         var t = await _db.ShiftTypes.FindAsync(new object?[] { instance.ShiftTypeId }, ct);
-        if (t is null) return ConflictResult.Fail("Shift type missing.");
+        if (t is null || t.CompanyId != instance.CompanyId)
+            return ConflictResult.Fail("Shift type missing.");
 
         // Approved Time off blocks
         bool hasTimeOff = await _db.TimeOffRequests


### PR DESCRIPTION
## Summary
- add tenant ownership to shift types and enforce the relationship in the EF model
- scope calendar, admin, and assignment flows to company-specific shift type definitions
- migrate existing shift type records to companies and enforce per-company uniqueness

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_b_68dac14cf3ec83298b586d5637078cd5