### PR TITLE
Add company scoping to shift types

### DIFF
--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -33,6 +33,11 @@ public class AppDbContext : DbContext
             .Property(p => p.Start).HasConversion(timeConverter);
         modelBuilder.Entity<ShiftType>()
             .Property(p => p.End).HasConversion(timeConverter);
+        modelBuilder.Entity<ShiftType>()
+            .HasOne(st => st.Company)
+            .WithMany()
+            .HasForeignKey(st => st.CompanyId)
+            .OnDelete(DeleteBehavior.Cascade);
 
         modelBuilder.Entity<ShiftInstance>()
             .Property(p => p.WorkDate).HasConversion(dateConverter);

--- a/Migrations/20250928210000_AddCompanyIdToShiftTypes.Designer.cs
+++ b/Migrations/20250928210000_AddCompanyIdToShiftTypes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ShiftManager.Data;
 
@@ -10,9 +11,11 @@ using ShiftManager.Data;
 namespace ShiftManager.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250928210000_AddCompanyIdToShiftTypes")]
+    partial class AddCompanyIdToShiftTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.9");

--- a/Migrations/20250928210000_AddCompanyIdToShiftTypes.cs
+++ b/Migrations/20250928210000_AddCompanyIdToShiftTypes.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShiftManager.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCompanyIdToShiftTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CompanyId",
+                table: "ShiftTypes",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.Sql(
+                "UPDATE \"ShiftTypes\" SET \"CompanyId\" = (SELECT \"Id\" FROM \"Companies\" ORDER BY \"Id\" LIMIT 1);");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShiftTypes_CompanyId",
+                table: "ShiftTypes",
+                column: "CompanyId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ShiftTypes_Companies_CompanyId",
+                table: "ShiftTypes",
+                column: "CompanyId",
+                principalTable: "Companies",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ShiftTypes_Companies_CompanyId",
+                table: "ShiftTypes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ShiftTypes_CompanyId",
+                table: "ShiftTypes");
+
+            migrationBuilder.DropColumn(
+                name: "CompanyId",
+                table: "ShiftTypes");
+        }
+    }
+}

--- a/Models/ShiftType.cs
+++ b/Models/ShiftType.cs
@@ -5,6 +5,8 @@ namespace ShiftManager.Models;
 public class ShiftType
 {
     public int Id { get; set; }
+    public int CompanyId { get; set; }
+    public Company Company { get; set; } = null!;
     public string Key { get; set; } = string.Empty; // MORNING, NOON, NIGHT, MIDDLE
     [NotMapped]
     public string Name

--- a/Pages/Admin/ShiftTypes.cshtml
+++ b/Pages/Admin/ShiftTypes.cshtml
@@ -18,6 +18,7 @@
                     <td><input class="input" name="items[@i].End" type="time" value="@Model.Items[i].End" /></td>
                     <input type="hidden" name="items[@i].Id" value="@Model.Items[i].Id" />
                     <input type="hidden" name="items[@i].Key" value="@Model.Items[i].Key" />
+                    <input type="hidden" name="items[@i].CompanyId" value="@Model.Items[i].CompanyId" />
                 </tr>
             }
             </tbody>

--- a/Pages/Calendar/Day.cshtml.cs
+++ b/Pages/Calendar/Day.cshtml.cs
@@ -54,7 +54,9 @@ public class DayModel : PageModel
         var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
 
         // Load shift types with custom ordering: morning, middle, noon, night
-        var types = await _db.ShiftTypes.ToListAsync();
+        var types = await _db.ShiftTypes
+            .Where(s => s.CompanyId == companyId)
+            .ToListAsync();
         types = types.OrderBy(s => s.Key switch
         {
             "MORNING" => 1,

--- a/Pages/Calendar/Month.cshtml.cs
+++ b/Pages/Calendar/Month.cshtml.cs
@@ -58,7 +58,10 @@ public class MonthModel : PageModel
         var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
 
         // Load shift types
-        var types = await _db.ShiftTypes.OrderBy(s => s.Key).ToListAsync();
+        var types = await _db.ShiftTypes
+            .Where(s => s.CompanyId == companyId)
+            .OrderBy(s => s.Key)
+            .ToListAsync();
 
         // Prepare shift types for JavaScript
         ViewData["ShiftTypes"] = types.Select(t => new

--- a/Pages/Calendar/Week.cshtml.cs
+++ b/Pages/Calendar/Week.cshtml.cs
@@ -62,7 +62,10 @@ public class WeekModel : PageModel
         var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
 
         // Load shift types
-        var types = await _db.ShiftTypes.OrderBy(s => s.Key).ToListAsync();
+        var types = await _db.ShiftTypes
+            .Where(s => s.CompanyId == companyId)
+            .OrderBy(s => s.Key)
+            .ToListAsync();
 
         // Prepare shift types for JavaScript
         ViewData["ShiftTypes"] = types.Select(t => new

--- a/Program.cs
+++ b/Program.cs
@@ -64,19 +64,26 @@ using (var scope = app.Services.CreateScope())
         await db.SaveChangesAsync();
     }
 
-    var company = db.Companies.First();
-
-    // Seed shift types (fixed keys)
-    if (!db.ShiftTypes.Any())
+    var companies = await db.Companies.ToListAsync();
+    foreach (var company in companies)
     {
-        db.ShiftTypes.AddRange(new[] {
-            new ShiftType{ Key="MORNING", Start=new TimeOnly(8,0), End=new TimeOnly(16,0)},
-            new ShiftType{ Key="NOON", Start=new TimeOnly(16,0), End=new TimeOnly(0,0)},
-            new ShiftType{ Key="NIGHT", Start=new TimeOnly(0,0), End=new TimeOnly(8,0)},
-            new ShiftType{ Key="MIDDLE", Start=new TimeOnly(12,0), End=new TimeOnly(20,0)},
-        });
+        if (!await db.ShiftTypes.AnyAsync(st => st.CompanyId == company.Id))
+        {
+            db.ShiftTypes.AddRange(new[]
+            {
+                new ShiftType{ CompanyId = company.Id, Key="MORNING", Start=new TimeOnly(8,0), End=new TimeOnly(16,0)},
+                new ShiftType{ CompanyId = company.Id, Key="NOON", Start=new TimeOnly(16,0), End=new TimeOnly(0,0)},
+                new ShiftType{ CompanyId = company.Id, Key="NIGHT", Start=new TimeOnly(0,0), End=new TimeOnly(8,0)},
+                new ShiftType{ CompanyId = company.Id, Key="MIDDLE", Start=new TimeOnly(12,0), End=new TimeOnly(20,0)},
+            });
+        }
+    }
+    if (db.ChangeTracker.HasChanges())
+    {
         await db.SaveChangesAsync();
     }
+
+    var company = companies.First();
 
     // Seed config
     if (!db.Configs.Any())


### PR DESCRIPTION
## Summary
- add a company relationship to shift types and seed per-company defaults
- add a migration that backfills existing shift types and enforces the new foreign key
- scope shift type UI and calendar usage to the caller's company and capture the company id in forms

## Testing
- Not Run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68dac110ca5083299772ded9414d4c81