### PR TITLE
Guard calendar adjustments against foreign shift types

### DIFF
--- a/Pages/Calendar/Month.cshtml.cs
+++ b/Pages/Calendar/Month.cshtml.cs
@@ -144,8 +144,19 @@ public class MonthModel : PageModel
         var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
         var date = DateOnly.Parse(payload.date);
 
+        var shiftType = await _db.ShiftTypes.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == payload.shiftTypeId);
+        if (shiftType == null || shiftType.CompanyId != companyId)
+        {
+            _logger.LogWarning(
+                "Attempt to adjust staffing with invalid shift type {ShiftTypeId} for company {CompanyId}",
+                payload.shiftTypeId,
+                companyId);
+            return BadRequest(new { message = "Invalid shift type." });
+        }
+
         var inst = await _db.ShiftInstances.FirstOrDefaultAsync(i =>
-            i.CompanyId == companyId && i.WorkDate == date && i.ShiftTypeId == payload.shiftTypeId);
+            i.CompanyId == companyId && i.WorkDate == date && i.ShiftTypeId == shiftType.Id);
         if (inst == null)
         {
             if (payload.delta < 0)
@@ -153,7 +164,7 @@ public class MonthModel : PageModel
             inst = new ShiftInstance
             {
                 CompanyId = companyId,
-                ShiftTypeId = payload.shiftTypeId,
+                ShiftTypeId = shiftType.Id,
                 WorkDate = date,
                 StaffingRequired = 0,
                 Concurrency = 0,

--- a/Pages/Calendar/Week.cshtml.cs
+++ b/Pages/Calendar/Week.cshtml.cs
@@ -141,8 +141,19 @@ public class WeekModel : PageModel
         var companyId = int.Parse(User.FindFirst("CompanyId")!.Value);
         var date = DateOnly.Parse(payload.date);
 
+        var shiftType = await _db.ShiftTypes.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == payload.shiftTypeId);
+        if (shiftType == null || shiftType.CompanyId != companyId)
+        {
+            _logger.LogWarning(
+                "Attempt to adjust staffing with invalid shift type {ShiftTypeId} for company {CompanyId}",
+                payload.shiftTypeId,
+                companyId);
+            return BadRequest(new { message = "Invalid shift type." });
+        }
+
         var inst = await _db.ShiftInstances.FirstOrDefaultAsync(i =>
-            i.CompanyId == companyId && i.WorkDate == date && i.ShiftTypeId == payload.shiftTypeId);
+            i.CompanyId == companyId && i.WorkDate == date && i.ShiftTypeId == shiftType.Id);
         if (inst == null)
         {
             if (payload.delta < 0)
@@ -150,7 +161,7 @@ public class WeekModel : PageModel
             inst = new ShiftInstance
             {
                 CompanyId = companyId,
-                ShiftTypeId = payload.shiftTypeId,
+                ShiftTypeId = shiftType.Id,
                 WorkDate = date,
                 StaffingRequired = 0,
                 Concurrency = 0,

--- a/ShiftManager.Tests/CalendarAdjustHandlerTests.cs
+++ b/ShiftManager.Tests/CalendarAdjustHandlerTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using ShiftManager.Data;
+using ShiftManager.Models;
+using ShiftManager.Pages.Calendar;
+using ShiftManager.Services;
+using Xunit;
+
+namespace ShiftManager.Tests;
+
+public class CalendarAdjustHandlerTests
+{
+    [Fact]
+    public async Task DayAdjust_ForeignShiftType_IsRejected()
+    {
+        await using var context = CreateContext();
+        var (companyA, companyB) = await SeedCompaniesAsync(context);
+
+        var foreignShiftType = await SeedShiftTypeAsync(context, companyB.Id);
+
+        var model = new DayModel(context, NullLogger<DayModel>.Instance, new ScheduleSummaryService(context));
+        AttachUser(model, companyId: companyA.Id);
+
+        var payload = new DayModel.AdjustPayload
+        {
+            date = DateOnly.FromDateTime(DateTime.Today).ToString("yyyy-MM-dd"),
+            shiftTypeId = foreignShiftType.Id,
+            delta = 1,
+            concurrency = 0
+        };
+
+        var result = await model.OnPostAdjustAsync(payload);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Empty(context.ShiftInstances);
+    }
+
+    [Fact]
+    public async Task WeekAdjust_ForeignShiftType_IsRejected()
+    {
+        await using var context = CreateContext();
+        var (companyA, companyB) = await SeedCompaniesAsync(context);
+
+        var foreignShiftType = await SeedShiftTypeAsync(context, companyB.Id);
+
+        var model = new WeekModel(context, NullLogger<WeekModel>.Instance, new ScheduleSummaryService(context));
+        AttachUser(model, companyId: companyA.Id);
+
+        var payload = new WeekModel.AdjustPayload
+        {
+            date = DateOnly.FromDateTime(DateTime.Today).ToString("yyyy-MM-dd"),
+            shiftTypeId = foreignShiftType.Id,
+            delta = 1,
+            concurrency = 0
+        };
+
+        var result = await model.OnPostAdjustAsync(payload);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Empty(context.ShiftInstances);
+    }
+
+    [Fact]
+    public async Task MonthAdjust_ForeignShiftType_IsRejected()
+    {
+        await using var context = CreateContext();
+        var (companyA, companyB) = await SeedCompaniesAsync(context);
+
+        var foreignShiftType = await SeedShiftTypeAsync(context, companyB.Id);
+
+        var model = new MonthModel(context, NullLogger<MonthModel>.Instance, new ScheduleSummaryService(context));
+        AttachUser(model, companyId: companyA.Id);
+
+        var payload = new MonthModel.AdjustPayload
+        {
+            date = DateOnly.FromDateTime(DateTime.Today).ToString("yyyy-MM-dd"),
+            shiftTypeId = foreignShiftType.Id,
+            delta = 1,
+            concurrency = 0
+        };
+
+        var result = await model.OnPostAdjustAsync(payload);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Empty(context.ShiftInstances);
+    }
+
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static async Task<(Company companyA, Company companyB)> SeedCompaniesAsync(AppDbContext context)
+    {
+        var companyA = new Company { Name = "Company A" };
+        var companyB = new Company { Name = "Company B" };
+        context.Companies.AddRange(companyA, companyB);
+        await context.SaveChangesAsync();
+        return (companyA, companyB);
+    }
+
+    private static async Task<ShiftType> SeedShiftTypeAsync(AppDbContext context, int companyId)
+    {
+        var shiftType = new ShiftType
+        {
+            CompanyId = companyId,
+            Key = "FOREIGN",
+            Name = "Foreign",
+            Start = new TimeOnly(8, 0),
+            End = new TimeOnly(16, 0)
+        };
+        context.ShiftTypes.Add(shiftType);
+        await context.SaveChangesAsync();
+        return shiftType;
+    }
+
+    private static void AttachUser(PageModel model, int companyId)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "1"),
+            new("CompanyId", companyId.ToString())
+        };
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+        var httpContext = new DefaultHttpContext { User = principal };
+        model.PageContext = new PageContext
+        {
+            HttpContext = httpContext
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- validate shift type ownership before adjusting staffing through the calendar pages
- reuse the verified shift type when creating new shift instances
- add regression tests that ensure foreign shift types are rejected

## Testing
- dotnet test *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68dae9fcbdf48329b754c9be04fa25db